### PR TITLE
Update pom.xml to fix building javadoc for newer Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>7</source>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Hello.
I've made a small changes to the pom.xml file to make the project easier to build on newer Java versions 1.7 <

Thank You for sharing this API on GitHub. :)